### PR TITLE
Add support for filtering when listing objects in `store.Store`

### DIFF
--- a/eventutils/event/event.go
+++ b/eventutils/event/event.go
@@ -57,7 +57,7 @@ func setListWatchSourceOptionsDefaults(o *ListWatchSourceOptions) {
 	}
 }
 
-func NewListWatchSource[E api.Object](listFunc func(ctx context.Context) (
+func NewListWatchSource[E api.Object](listFunc func(ctx context.Context, opts ...store.ListOption) (
 	[]E, error),
 	watchFunc func(ctx context.Context) (store.Watch[E], error),
 	opts ListWatchSourceOptions,
@@ -73,7 +73,7 @@ func NewListWatchSource[E api.Object](listFunc func(ctx context.Context) (
 }
 
 type ListWatchSource[E api.Object] struct {
-	listFunc  func(ctx context.Context) ([]E, error)
+	listFunc  func(ctx context.Context, opts ...store.ListOption) ([]E, error)
 	watchFunc func(ctx context.Context) (store.Watch[E], error)
 
 	handlesMu sync.RWMutex

--- a/eventutils/event/event.go
+++ b/eventutils/event/event.go
@@ -49,6 +49,7 @@ type Event[E api.Object] struct {
 
 type ListWatchSourceOptions struct {
 	ResyncDuration time.Duration
+	ListOptions    []store.ListOption
 }
 
 func setListWatchSourceOptionsDefaults(o *ListWatchSourceOptions) {
@@ -69,14 +70,16 @@ func NewListWatchSource[E api.Object](listFunc ListFunc[E],
 	return &ListWatchSource[E]{
 		listFunc:       listFunc,
 		watchFunc:      watchFunc,
+		listOptions:    opts.ListOptions,
 		handles:        sets.New[*handle[E]](),
 		resyncDuration: opts.ResyncDuration,
 	}, nil
 }
 
 type ListWatchSource[E api.Object] struct {
-	listFunc  ListFunc[E]
-	watchFunc WatchFunc[E]
+	listFunc    ListFunc[E]
+	watchFunc   WatchFunc[E]
+	listOptions []store.ListOption
 
 	handlesMu sync.RWMutex
 	handles   sets.Set[*handle[E]]
@@ -88,7 +91,7 @@ func (s *ListWatchSource[E]) Start(ctx context.Context) error {
 	log := logr.FromContextOrDiscard(ctx)
 	var wg sync.WaitGroup
 
-	watch, err := s.watchFunc(ctx)
+	watch, err := s.watchFunc(ctx, s.listOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to start watch: %w", err)
 	}
@@ -122,7 +125,7 @@ func (s *ListWatchSource[E]) Start(ctx context.Context) error {
 		defer wg.Done()
 
 		wait.UntilWithContext(ctx, func(ctx context.Context) {
-			objs, err := s.listFunc(ctx)
+			objs, err := s.listFunc(ctx, s.listOptions...)
 			if err != nil {
 				log.Error(err, "failed to list objects")
 				return

--- a/eventutils/event/event.go
+++ b/eventutils/event/event.go
@@ -58,7 +58,7 @@ func setListWatchSourceOptionsDefaults(o *ListWatchSourceOptions) {
 }
 
 type ListFunc[E api.Object] func(context.Context, ...store.ListOption) ([]E, error)
-type WatchFunc[E api.Object] func(context.Context) (store.Watch[E], error)
+type WatchFunc[E api.Object] func(context.Context, ...store.ListOption) (store.Watch[E], error)
 
 func NewListWatchSource[E api.Object](listFunc ListFunc[E],
 	watchFunc WatchFunc[E],

--- a/eventutils/event/event.go
+++ b/eventutils/event/event.go
@@ -57,9 +57,11 @@ func setListWatchSourceOptionsDefaults(o *ListWatchSourceOptions) {
 	}
 }
 
-func NewListWatchSource[E api.Object](listFunc func(ctx context.Context, opts ...store.ListOption) (
-	[]E, error),
-	watchFunc func(ctx context.Context) (store.Watch[E], error),
+type ListFunc[E api.Object] func(context.Context, ...store.ListOption) ([]E, error)
+type WatchFunc[E api.Object] func(context.Context) (store.Watch[E], error)
+
+func NewListWatchSource[E api.Object](listFunc ListFunc[E],
+	watchFunc WatchFunc[E],
 	opts ListWatchSourceOptions,
 ) (*ListWatchSource[E], error) {
 	setListWatchSourceOptionsDefaults(&opts)
@@ -73,8 +75,8 @@ func NewListWatchSource[E api.Object](listFunc func(ctx context.Context, opts ..
 }
 
 type ListWatchSource[E api.Object] struct {
-	listFunc  func(ctx context.Context, opts ...store.ListOption) ([]E, error)
-	watchFunc func(ctx context.Context) (store.Watch[E], error)
+	listFunc  ListFunc[E]
+	watchFunc WatchFunc[E]
 
 	handlesMu sync.RWMutex
 	handles   sets.Set[*handle[E]]

--- a/storeutils/host/host_suite_test.go
+++ b/storeutils/host/host_suite_test.go
@@ -19,11 +19,13 @@ import (
 
 type Dummy struct {
 	api.Metadata `json:"metadata,omitempty"`
+	Spec         string `json:"spec,omitempty"`
 }
 
 var (
-	tmpDir     string
-	dummyStore store.Store[*Dummy]
+	tmpDir          string
+	dummyStore      store.Store[*Dummy]
+	dummyStoreField *host.Store[*Dummy]
 )
 
 const (
@@ -53,6 +55,18 @@ var _ = BeforeSuite(func() {
 		Dir: tmpDir,
 		NewFunc: func() *Dummy {
 			return &Dummy{}
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	fieldTmpDir := GinkgoT().TempDir()
+	dummyStoreField, err = host.NewStore[*Dummy](host.Options[*Dummy]{
+		Dir: fieldTmpDir,
+		NewFunc: func() *Dummy {
+			return &Dummy{}
+		},
+		FieldIndexers: map[string]store.IndexerFunc[*Dummy]{
+			"spec": func(d *Dummy) string { return d.Spec },
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/storeutils/host/store.go
+++ b/storeutils/host/store.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	utilssync "github.com/ironcore-dev/provider-utils/storeutils/sync"
 	"github.com/ironcore-dev/provider-utils/storeutils/utils"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -26,6 +28,7 @@ type Options[E api.Object] struct {
 	NewFunc         func() E
 	CreateStrategy  CreateStrategy[E]
 	WatchBufferSize int
+	FieldIndexers   map[string]store.IndexerFunc[E]
 }
 
 func (o *Options[E]) Defaults() {
@@ -45,6 +48,10 @@ func NewStore[E api.Object](opts Options[E]) (*Store[E], error) {
 		return nil, fmt.Errorf("error creating store directory: %w", err)
 	}
 
+	indexers := make(map[string]store.IndexerFunc[E], len(opts.FieldIndexers))
+	for k, v := range opts.FieldIndexers {
+		indexers[k] = v
+	}
 	return &Store[E]{
 		dir: opts.Dir,
 
@@ -55,6 +62,8 @@ func NewStore[E api.Object](opts Options[E]) (*Store[E], error) {
 
 		watches:         sets.New[*watch[E]](),
 		watchBufferSize: opts.WatchBufferSize,
+
+		indexers: indexers,
 	}, nil
 }
 
@@ -69,6 +78,8 @@ type Store[E api.Object] struct {
 	watchBufferSize int
 	watchesMu       sync.RWMutex
 	watches         sets.Set[*watch[E]]
+
+	indexers map[string]store.IndexerFunc[E]
 }
 
 type CreateStrategy[E api.Object] interface {
@@ -192,7 +203,20 @@ func (s *Store[E]) Delete(_ context.Context, id string) error {
 	return nil
 }
 
-func (s *Store[E]) List(ctx context.Context) ([]E, error) {
+func (s *Store[E]) List(ctx context.Context, opts ...store.ListOption) ([]E, error) {
+	listOpts := &store.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(listOpts)
+	}
+
+	if listOpts.FieldSelector != nil {
+		for _, req := range listOpts.FieldSelector.Requirements() {
+			if _, ok := s.indexers[req.Field]; !ok {
+				return nil, fmt.Errorf("field selector references unindexed field %q", req.Field)
+			}
+		}
+	}
+
 	entries, err := os.ReadDir(s.dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list objects: %w", err)
@@ -208,6 +232,22 @@ func (s *Store[E]) List(ctx context.Context) ([]E, error) {
 		object, err := s.Get(ctx, entry.Name())
 		if err != nil {
 			return nil, fmt.Errorf("failed to read object: %w", err)
+		}
+
+		if listOpts.LabelSelector != nil && !listOpts.LabelSelector.Matches(labels.Set(object.GetLabels())) {
+			continue
+		}
+
+		if listOpts.FieldSelector != nil {
+			merged := fields.Set{}
+			for _, req := range listOpts.FieldSelector.Requirements() {
+				if fn, ok := s.indexers[req.Field]; ok {
+					merged[req.Field] = fn(object)
+				}
+			}
+			if !listOpts.FieldSelector.Matches(merged) {
+				continue
+			}
 		}
 
 		objs = append(objs, object)

--- a/storeutils/host/store.go
+++ b/storeutils/host/store.go
@@ -203,18 +203,44 @@ func (s *Store[E]) Delete(_ context.Context, id string) error {
 	return nil
 }
 
+func (s *Store[E]) validateFieldSelector(opts store.ListOptions) error {
+	if opts.FieldSelector == nil {
+		return nil
+	}
+	for _, req := range opts.FieldSelector.Requirements() {
+		if _, ok := s.indexers[req.Field]; !ok {
+			return fmt.Errorf("field selector references unindexed field %q", req.Field)
+		}
+	}
+	return nil
+}
+
+func (s *Store[E]) matchesOptions(obj E, opts store.ListOptions) bool {
+	if opts.LabelSelector != nil && !opts.LabelSelector.Matches(labels.Set(obj.GetLabels())) {
+		return false
+	}
+	if opts.FieldSelector != nil {
+		merged := fields.Set{}
+		for _, req := range opts.FieldSelector.Requirements() {
+			if fn, ok := s.indexers[req.Field]; ok {
+				merged[req.Field] = fn(obj)
+			}
+		}
+		if !opts.FieldSelector.Matches(merged) {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *Store[E]) List(ctx context.Context, opts ...store.ListOption) ([]E, error) {
 	listOpts := &store.ListOptions{}
 	for _, opt := range opts {
 		opt.ApplyToList(listOpts)
 	}
 
-	if listOpts.FieldSelector != nil {
-		for _, req := range listOpts.FieldSelector.Requirements() {
-			if _, ok := s.indexers[req.Field]; !ok {
-				return nil, fmt.Errorf("field selector references unindexed field %q", req.Field)
-			}
-		}
+	if err := s.validateFieldSelector(*listOpts); err != nil {
+		return nil, err
 	}
 
 	entries, err := os.ReadDir(s.dir)
@@ -234,20 +260,8 @@ func (s *Store[E]) List(ctx context.Context, opts ...store.ListOption) ([]E, err
 			return nil, fmt.Errorf("failed to read object: %w", err)
 		}
 
-		if listOpts.LabelSelector != nil && !listOpts.LabelSelector.Matches(labels.Set(object.GetLabels())) {
+		if !s.matchesOptions(object, *listOpts) {
 			continue
-		}
-
-		if listOpts.FieldSelector != nil {
-			merged := fields.Set{}
-			for _, req := range listOpts.FieldSelector.Requirements() {
-				if fn, ok := s.indexers[req.Field]; ok {
-					merged[req.Field] = fn(object)
-				}
-			}
-			if !listOpts.FieldSelector.Matches(merged) {
-				continue
-			}
 		}
 
 		objs = append(objs, object)
@@ -256,13 +270,24 @@ func (s *Store[E]) List(ctx context.Context, opts ...store.ListOption) ([]E, err
 	return objs, nil
 }
 
-func (s *Store[E]) Watch(_ context.Context) (store.Watch[E], error) {
+func (s *Store[E]) Watch(_ context.Context, opts ...store.ListOption) (store.Watch[E], error) {
+	listOpts := &store.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(listOpts)
+	}
+
+	if err := s.validateFieldSelector(*listOpts); err != nil {
+		return nil, err
+	}
+
 	s.watchesMu.Lock()
 	defer s.watchesMu.Unlock()
 
 	w := &watch[E]{
-		store:  s,
-		events: make(chan store.WatchEvent[E], s.watchBufferSize),
+		store:   s,
+		events:  make(chan store.WatchEvent[E], s.watchBufferSize),
+		opts:    *listOpts,
+		members: sets.New[string](),
 	}
 
 	s.watches.Insert(w)
@@ -321,11 +346,23 @@ func (s *Store[E]) watchHandlers() []*watch[E] {
 	return s.watches.UnsortedList()
 }
 
+func (s *Store[E]) send(w *watch[E], evt store.WatchEvent[E]) {
+	select {
+	case w.events <- evt:
+	default:
+	}
+}
+
 func (s *Store[E]) enqueue(evt store.WatchEvent[E]) {
+	id := evt.Object.GetID()
 	for _, handler := range s.watchHandlers() {
-		select {
-		case handler.events <- evt:
-		default:
+		if handler.matches(evt.Object) {
+			handler.members.Insert(id)
+			s.send(handler, evt)
+		} else if handler.members.Has(id) {
+			// Object transitioned out of this watch's scope. Send deleted event.
+			handler.members.Delete(id)
+			s.send(handler, store.WatchEvent[E]{Type: store.WatchEventTypeDeleted, Object: evt.Object})
 		}
 	}
 }

--- a/storeutils/host/store_test.go
+++ b/storeutils/host/store_test.go
@@ -136,4 +136,79 @@ var _ = Describe("Store", func() {
 		Expect(filtered).To(HaveLen(1))
 		Expect(filtered[0].GetID()).To(Equal("combined-a"))
 	})
+
+	Describe("Watch", func() {
+		It("should receive events without a filter", func(ctx SpecContext) {
+			watch, err := dummyStore.Watch(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(watch.Stop)
+
+			obj := createDummy(ctx, dummyStore, "watch-no-filter", nil, "")
+			event := store.WatchEvent[*Dummy]{Type: store.WatchEventTypeCreated, Object: obj}
+			Eventually(watch.Events()).Should(Receive(Equal(event)))
+		})
+
+		It("should only receive events for objects matching a label selector", func(ctx SpecContext) {
+			watch, err := dummyStore.Watch(ctx, store.MatchingLabels{"app": "watched"})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(watch.Stop)
+
+			By("creating a non-matching object")
+			createDummy(ctx, dummyStore, "watch-label-ignored", map[string]string{"app": "other"}, "")
+
+			By("checking that the non-matching event is not received")
+			Consistently(watch.Events()).ShouldNot(Receive())
+
+			By("creating a matching object")
+			obj := createDummy(ctx, dummyStore, "watch-label-matched", map[string]string{"app": "watched"}, "")
+
+			event := store.WatchEvent[*Dummy]{Type: store.WatchEventTypeCreated, Object: obj}
+			Eventually(watch.Events()).Should(Receive(Equal(event)))
+		})
+
+		It("should only receive events for objects matching a field selector", func(ctx SpecContext) {
+			watch, err := dummyStoreField.Watch(ctx, store.MatchingFields{"spec": "ssd"})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(watch.Stop)
+
+			By("creating a non-matching object")
+			createDummy(ctx, dummyStoreField, "watch-field-ignored", nil, "hdd")
+
+			By("checking that the non-matching event is not received")
+			Consistently(watch.Events()).ShouldNot(Receive())
+
+			By("creating a matching object")
+			obj := createDummy(ctx, dummyStoreField, "watch-field-matched", nil, "ssd")
+
+			event := store.WatchEvent[*Dummy]{Type: store.WatchEventTypeCreated, Object: obj}
+			Eventually(watch.Events()).Should(Receive(Equal(event)))
+		})
+
+		It("should only receive events matching combined label and field selectors", func(ctx SpecContext) {
+			watch, err := dummyStoreField.Watch(ctx,
+				store.MatchingLabels{"env": "prod"},
+				store.MatchingFields{"spec": "ssd"},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(watch.Stop)
+
+			By("creating objects that only partially match")
+			createDummy(ctx, dummyStoreField, "watch-combined-label-only", map[string]string{"env": "prod"}, "hdd")
+			createDummy(ctx, dummyStoreField, "watch-combined-field-only", map[string]string{"env": "dev"}, "ssd")
+
+			Consistently(watch.Events()).ShouldNot(Receive())
+
+			By("creating the object that matches both selectors")
+			obj := createDummy(ctx, dummyStoreField, "watch-combined-matched", map[string]string{"env": "prod"}, "ssd")
+
+			event := store.WatchEvent[*Dummy]{Type: store.WatchEventTypeCreated, Object: obj}
+			Eventually(watch.Events()).Should(Receive(Equal(event)))
+		})
+
+		It("should return an error when Watch references an unindexed field", func(ctx SpecContext) {
+			_, err := dummyStoreField.Watch(ctx, store.MatchingFields{"nonexistent": "value"})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unindexed field"))
+		})
+	})
 })

--- a/storeutils/host/store_test.go
+++ b/storeutils/host/store_test.go
@@ -4,6 +4,7 @@
 package host_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -12,6 +13,16 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func createDummy(ctx context.Context, s store.Store[*Dummy], id string, labels map[string]string, spec string) *Dummy {
+	obj, err := s.Create(ctx, &Dummy{
+		Metadata: api.Metadata{ID: id, Labels: labels},
+		Spec:     spec,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(s.Delete, ctx, id)
+	return obj
+}
 
 var _ = Describe("Store", func() {
 
@@ -29,6 +40,7 @@ var _ = Describe("Store", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(obj).NotTo(BeNil())
+		DeferCleanup(dummyStore.Delete, ctx, "test-id")
 
 		By("checking that the store object exists")
 		data, err := os.ReadFile(filepath.Join(tmpDir, obj.ID))
@@ -41,5 +53,87 @@ var _ = Describe("Store", func() {
 			Object: obj,
 		}
 		Eventually(watch.Events()).Should(Receive(event))
+	})
+
+	It("should filter objects by labels using MatchingLabels", func(ctx SpecContext) {
+		By("creating objects with different labels")
+		createDummy(ctx, dummyStore, "labeled-a", map[string]string{"app": "foo", "env": "prod"}, "")
+		createDummy(ctx, dummyStore, "labeled-b", map[string]string{"app": "bar", "env": "prod"}, "")
+		createDummy(ctx, dummyStore, "labeled-c", map[string]string{"app": "foo", "env": "dev"}, "")
+
+		By("listing without filter returns all objects")
+		all, err := dummyStore.List(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(all).To(HaveLen(3))
+
+		By("listing with MatchingLabels filters correctly")
+		filtered, err := dummyStore.List(ctx, store.MatchingLabels{"app": "foo"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(2))
+		for _, obj := range filtered {
+			Expect(obj.GetLabels()["app"]).To(Equal("foo"))
+		}
+
+		By("listing with multiple label selectors")
+		filtered, err = dummyStore.List(ctx, store.MatchingLabels{"app": "foo", "env": "prod"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(1))
+		Expect(filtered[0].GetID()).To(Equal("labeled-a"))
+
+		By("listing with HasLabels filters by key existence")
+		filtered, err = dummyStore.List(ctx, store.HasLabels{"env"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(3))
+
+		By("listing with HasLabels for a non-existent key")
+		filtered, err = dummyStore.List(ctx, store.HasLabels{"missing"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(BeEmpty())
+
+		By("combining MatchingLabels and HasLabels")
+		filtered, err = dummyStore.List(ctx, store.MatchingLabels{"env": "prod"}, store.HasLabels{"app"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(2))
+	})
+
+	It("should filter objects by fields using MatchingFields", func(ctx SpecContext) {
+		By("creating objects with different spec values")
+		createDummy(ctx, dummyStoreField, "field-ssd-a", nil, "ssd")
+		createDummy(ctx, dummyStoreField, "field-ssd-b", nil, "ssd")
+		createDummy(ctx, dummyStoreField, "field-hdd", nil, "hdd")
+
+		By("listing with MatchingFields filters by field value")
+		filtered, err := dummyStoreField.List(ctx, store.MatchingFields{"spec": "ssd"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(2))
+		for _, obj := range filtered {
+			Expect(obj.Spec).To(Equal("ssd"))
+		}
+
+		By("listing with MatchingFields returns nothing for unmatched value")
+		filtered, err = dummyStoreField.List(ctx, store.MatchingFields{"spec": "nvme"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(BeEmpty())
+	})
+
+	It("should return an error when List references an unindexed field", func(ctx SpecContext) {
+		_, err := dummyStoreField.List(ctx, store.MatchingFields{"nonexistent": "value"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unindexed field"))
+	})
+
+	It("should apply label and field selectors as AND when both are set", func(ctx SpecContext) {
+		createDummy(ctx, dummyStoreField, "combined-a", map[string]string{"env": "prod"}, "ssd")
+		createDummy(ctx, dummyStoreField, "combined-b", map[string]string{"env": "prod"}, "hdd")
+		createDummy(ctx, dummyStoreField, "combined-c", map[string]string{"env": "dev"}, "ssd")
+
+		By("only the object matching both selectors is returned")
+		filtered, err := dummyStoreField.List(ctx,
+			store.MatchingLabels{"env": "prod"},
+			store.MatchingFields{"spec": "ssd"},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(1))
+		Expect(filtered[0].GetID()).To(Equal("combined-a"))
 	})
 })

--- a/storeutils/host/watch.go
+++ b/storeutils/host/watch.go
@@ -6,11 +6,18 @@ package host
 import (
 	"github.com/ironcore-dev/provider-utils/apiutils/api"
 	"github.com/ironcore-dev/provider-utils/storeutils/store"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type watch[E api.Object] struct {
-	store  *Store[E]
-	events chan store.WatchEvent[E]
+	store   *Store[E]
+	events  chan store.WatchEvent[E]
+	opts    store.ListOptions
+	members sets.Set[string]
+}
+
+func (w *watch[E]) matches(obj E) bool {
+	return w.store.matchesOptions(obj, w.opts)
 }
 
 func (w *watch[E]) Stop() {

--- a/storeutils/store/listoptions.go
+++ b/storeutils/store/listoptions.go
@@ -4,12 +4,14 @@
 package store
 
 import (
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
 type ListOptions struct {
 	LabelSelector labels.Selector
+	FieldSelector fields.Selector
 }
 
 type ListOption interface {
@@ -46,4 +48,15 @@ func andSelectors(existing, additional labels.Selector) labels.Selector {
 	}
 	reqs, _ := additional.Requirements()
 	return existing.Add(reqs...)
+}
+
+type MatchingFields fields.Set
+
+func (m MatchingFields) ApplyToList(o *ListOptions) {
+	sel := fields.Set(m).AsSelector()
+	if o.FieldSelector == nil {
+		o.FieldSelector = sel
+	} else {
+		o.FieldSelector = fields.AndSelectors(o.FieldSelector, sel)
+	}
 }

--- a/storeutils/store/listoptions.go
+++ b/storeutils/store/listoptions.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type ListOptions struct {
+	LabelSelector labels.Selector
+}
+
+type ListOption interface {
+	ApplyToList(*ListOptions)
+}

--- a/storeutils/store/listoptions.go
+++ b/storeutils/store/listoptions.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 type ListOptions struct {
@@ -13,4 +14,36 @@ type ListOptions struct {
 
 type ListOption interface {
 	ApplyToList(*ListOptions)
+}
+
+type MatchingLabels labels.Set
+
+func (m MatchingLabels) ApplyToList(o *ListOptions) {
+	sel := labels.SelectorFromSet(labels.Set(m))
+	o.LabelSelector = andSelectors(o.LabelSelector, sel)
+}
+
+type HasLabels []string
+
+func (h HasLabels) ApplyToList(o *ListOptions) {
+	sel := labels.NewSelector()
+	for _, key := range h {
+		req, err := labels.NewRequirement(key, selection.Exists, nil)
+		// Invalid labels are ignored, leading to an empty selector.
+		// This is in line with the behavior of controller-runtime:
+		// https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/client/options.go#L637-L644
+		if err != nil {
+			continue
+		}
+		sel = sel.Add(*req)
+	}
+	o.LabelSelector = andSelectors(o.LabelSelector, sel)
+}
+
+func andSelectors(existing, additional labels.Selector) labels.Selector {
+	if existing == nil {
+		return additional
+	}
+	reqs, _ := additional.Requirements()
+	return existing.Add(reqs...)
 }

--- a/storeutils/store/store.go
+++ b/storeutils/store/store.go
@@ -51,5 +51,5 @@ type Store[E api.Object] interface {
 	Delete(ctx context.Context, id string) error
 	List(ctx context.Context, opts ...ListOption) ([]E, error)
 
-	Watch(ctx context.Context) (Watch[E], error)
+	Watch(ctx context.Context, opts ...ListOption) (Watch[E], error)
 }

--- a/storeutils/store/store.go
+++ b/storeutils/store/store.go
@@ -42,12 +42,14 @@ const (
 	WatchEventTypeDeleted WatchEventType = "Deleted"
 )
 
+type IndexerFunc[E api.Object] func(E) string
+
 type Store[E api.Object] interface {
 	Create(ctx context.Context, obj E) (E, error)
 	Get(ctx context.Context, id string) (E, error)
 	Update(ctx context.Context, obj E) (E, error)
 	Delete(ctx context.Context, id string) error
-	List(ctx context.Context) ([]E, error)
+	List(ctx context.Context, opts ...ListOption) ([]E, error)
 
 	Watch(ctx context.Context) (Watch[E], error)
 }


### PR DESCRIPTION
# Summary

Extend the `List` method of the `store.Store` interface to allow filtering of
objects. This allows for native filtering, instead of requiring clients to list
all objects in the store and then filter on the cleint side.

Also extend `host.Store` for the new interface.

# Proposed Changes

- Add ListOptions to `store.Store`
- Implement `HasLabels`, `MatchingLabels` and `MatchingFields` ListOptions
- Extend `host.Store` to support ListOptions

Fixes #55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Listing and watching now support variadic selector filtering via list options (label selectors and field selectors).
  * Added helper list options for exact label matches, “has label key” filtering, and field value matching (enabled when the store is configured for field indexing).
* **Bug Fixes**
  * Ensures label + field constraints are applied together (AND semantics), including correct watch event scoping and transitions out of scope.
* **Tests**
  * Expanded list/watch coverage, including empty-result cases and clear errors for unindexed field filters.
* **Documentation**
  * Updated list/watch related signatures to accept the new list options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->