### PR TITLE
Add action field to event recorder

### DIFF
--- a/eventutils/recorder/event.go
+++ b/eventutils/recorder/event.go
@@ -14,9 +14,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// EventRecorder defines an interface for recording events
+// EventRecorder defines an interface for recording events.
+//
+// The action argument names the operation the reporter performed (e.g. "Destroy",
+// "AttachVolume", "Pull") and is distinct from reason, which names the outcome.
+// It must be non-empty: downstream consumers publish events into the
+// events.k8s.io/v1 API where action is a required field.
 type EventRecorder interface {
-	Eventf(apiMetadata api.Metadata, eventType string, reason string, messageFormat string, args ...any)
+	Eventf(apiMetadata api.Metadata, eventType, reason, action, messageFormat string, args ...any)
 }
 
 // EventStore defines an interface for listing events
@@ -28,6 +33,7 @@ type Event struct {
 	InvolvedObjectMeta api.Metadata
 	Type               string
 	Reason             string
+	Action             string
 	Message            string
 	EventTime          int64
 }
@@ -82,12 +88,12 @@ func NewEventStore(log logr.Logger, opts EventStoreOptions) *Store {
 }
 
 // Eventf logs and records an event with formatted message.
-func (es *Store) Eventf(apiMetadata api.Metadata, eventType, reason, messageFormat string, args ...any) {
-	es.recordEvent(apiMetadata, eventType, reason, fmt.Sprintf(messageFormat, args...))
+func (es *Store) Eventf(apiMetadata api.Metadata, eventType, reason, action, messageFormat string, args ...any) {
+	es.recordEvent(apiMetadata, eventType, reason, action, fmt.Sprintf(messageFormat, args...))
 }
 
 // recordEvent adds a new Event to the store. Implements the EventRecorder interface.
-func (es *Store) recordEvent(metadata api.Metadata, eventType, reason, message string) {
+func (es *Store) recordEvent(metadata api.Metadata, eventType, reason, action, message string) {
 	es.mutex.Lock()
 	defer es.mutex.Unlock()
 
@@ -106,6 +112,7 @@ func (es *Store) recordEvent(metadata api.Metadata, eventType, reason, message s
 		InvolvedObjectMeta: metadata,
 		Type:               eventType,
 		Reason:             reason,
+		Action:             action,
 		Message:            message,
 		EventTime:          time.Now().Unix(),
 	}
@@ -157,6 +164,7 @@ func (es *Store) ListEvents() []*Event {
 			InvolvedObjectMeta: event.InvolvedObjectMeta,
 			Type:               event.Type,
 			Reason:             event.Reason,
+			Action:             event.Action,
 			Message:            event.Message,
 			EventTime:          event.EventTime,
 		})

--- a/eventutils/recorder/event_test.go
+++ b/eventutils/recorder/event_test.go
@@ -28,6 +28,7 @@ const (
 	eventTTL       = 2 * time.Second
 	eventType      = "TestType"
 	reason         = "TestReason"
+	action         = "TestAction"
 	message        = "TestMessage"
 	resyncInterval = 2 * time.Second
 )
@@ -69,19 +70,24 @@ var _ = Describe("Machine EventStore", func() {
 
 	Context("AddEvent", func() {
 		It("should add an event to the store", func() {
-			es.Eventf(apiMetadata, eventType, reason, message)
+			es.Eventf(apiMetadata, eventType, reason, action, message)
 			Expect(logOutput.String()).To(BeEmpty())
-			Expect(es.ListEvents()).To(HaveLen(1))
+			events := es.ListEvents()
+			Expect(events).To(HaveLen(1))
+			Expect(events[0].Reason).To(Equal(reason))
+			Expect(events[0].Action).To(Equal(action))
+			Expect(events[0].Message).To(Equal(message))
+			Expect(events[0].Type).To(Equal(eventType))
 		})
 
 		It("should override the oldest event when the store is full", func() {
 			for i := 0; i < maxEvents; i++ {
-				es.Eventf(apiMetadata, eventType, reason, "%s %d", message, i)
+				es.Eventf(apiMetadata, eventType, reason, action, "%s %d", message, i)
 				Expect(logOutput.String()).To(BeEmpty())
 				Expect(es.ListEvents()).To(HaveLen(i + 1))
 			}
 
-			es.Eventf(apiMetadata, eventType, reason, "New Event")
+			es.Eventf(apiMetadata, eventType, reason, action, "New Event")
 			Expect(logOutput.String()).To(BeEmpty())
 
 			events := es.ListEvents()
@@ -97,7 +103,7 @@ var _ = Describe("Machine EventStore", func() {
 
 	Context("removeExpiredEvents", func() {
 		It("should remove events whose TTL has expired", func() {
-			es.Eventf(apiMetadata, eventType, reason, message)
+			es.Eventf(apiMetadata, eventType, reason, action, message)
 			Expect(logOutput.String()).To(BeEmpty())
 			Expect(es.ListEvents()).To(HaveLen(1))
 
@@ -112,7 +118,7 @@ var _ = Describe("Machine EventStore", func() {
 		})
 
 		It("should not remove events whose TTL has not expired", func() {
-			es.Eventf(apiMetadata, eventType, reason, message)
+			es.Eventf(apiMetadata, eventType, reason, action, message)
 			Expect(logOutput.String()).To(BeEmpty())
 			Expect(es.ListEvents()).To(HaveLen(1))
 
@@ -132,7 +138,7 @@ var _ = Describe("Machine EventStore", func() {
 
 			go es.Start(ctx)
 
-			es.Eventf(apiMetadata, eventType, reason, message)
+			es.Eventf(apiMetadata, eventType, reason, action, message)
 			Expect(logOutput.String()).To(BeEmpty())
 			Expect(es.ListEvents()).To(HaveLen(1))
 
@@ -144,7 +150,7 @@ var _ = Describe("Machine EventStore", func() {
 
 	Context("ListEvents", func() {
 		It("should return all current events", func() {
-			es.Eventf(apiMetadata, eventType, reason, message)
+			es.Eventf(apiMetadata, eventType, reason, action, message)
 			Expect(logOutput.String()).To(BeEmpty())
 
 			events := es.ListEvents()
@@ -153,7 +159,7 @@ var _ = Describe("Machine EventStore", func() {
 		})
 
 		It("should return a copy of events", func() {
-			es.Eventf(apiMetadata, eventType, reason, message)
+			es.Eventf(apiMetadata, eventType, reason, action, message)
 			Expect(logOutput.String()).To(BeEmpty())
 			events := es.ListEvents()
 			Expect(events).To(HaveLen(1))


### PR DESCRIPTION
The events.k8s.io/v1 API requires a non-empty action on every event. Extend the recorder interface, Event struct, and Store to carry an explicit action so providers can populate it end-to-end via IRI.

Breaking change: all callers must pass action to Eventf.

Contributes to #ironcore-dev/ironcore#1489

