### PR TITLE
Implement indexing for `host.Store`

### DIFF
--- a/eventutils/event/event.go
+++ b/eventutils/event/event.go
@@ -57,7 +57,7 @@ func setListWatchSourceOptionsDefaults(o *ListWatchSourceOptions) {
 	}
 }
 
-func NewListWatchSource[E api.Object](listFunc func(ctx context.Context) (
+func NewListWatchSource[E api.Object](listFunc func(ctx context.Context, opts ...store.ListOption) (
 	[]E, error),
 	watchFunc func(ctx context.Context) (store.Watch[E], error),
 	opts ListWatchSourceOptions,
@@ -73,7 +73,7 @@ func NewListWatchSource[E api.Object](listFunc func(ctx context.Context) (
 }
 
 type ListWatchSource[E api.Object] struct {
-	listFunc  func(ctx context.Context) ([]E, error)
+	listFunc  func(ctx context.Context, opts ...store.ListOption) ([]E, error)
 	watchFunc func(ctx context.Context) (store.Watch[E], error)
 
 	handlesMu sync.RWMutex

--- a/storeutils/host/host_suite_test.go
+++ b/storeutils/host/host_suite_test.go
@@ -19,11 +19,13 @@ import (
 
 type Dummy struct {
 	api.Metadata `json:"metadata,omitempty"`
+	Spec         string `json:"spec,omitempty"`
 }
 
 var (
-	tmpDir     string
-	dummyStore store.Store[*Dummy]
+	tmpDir          string
+	dummyStore      store.Store[*Dummy]
+	dummyStoreField *host.Store[*Dummy]
 )
 
 const (
@@ -53,6 +55,18 @@ var _ = BeforeSuite(func() {
 		Dir: tmpDir,
 		NewFunc: func() *Dummy {
 			return &Dummy{}
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	fieldTmpDir := GinkgoT().TempDir()
+	dummyStoreField, err = host.NewStore[*Dummy](host.Options[*Dummy]{
+		Dir: fieldTmpDir,
+		NewFunc: func() *Dummy {
+			return &Dummy{}
+		},
+		FieldIndexers: map[string]store.IndexerFunc[*Dummy]{
+			"spec": func(d *Dummy) string { return d.Spec },
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())

--- a/storeutils/host/store.go
+++ b/storeutils/host/store.go
@@ -17,6 +17,8 @@ import (
 	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	utilssync "github.com/ironcore-dev/provider-utils/storeutils/sync"
 	"github.com/ironcore-dev/provider-utils/storeutils/utils"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -26,6 +28,7 @@ type Options[E api.Object] struct {
 	NewFunc         func() E
 	CreateStrategy  CreateStrategy[E]
 	WatchBufferSize int
+	FieldIndexers   map[string]store.IndexerFunc[E]
 }
 
 func (o *Options[E]) Defaults() {
@@ -45,6 +48,10 @@ func NewStore[E api.Object](opts Options[E]) (*Store[E], error) {
 		return nil, fmt.Errorf("error creating store directory: %w", err)
 	}
 
+	indexers := make(map[string]store.IndexerFunc[E], len(opts.FieldIndexers))
+	for k, v := range opts.FieldIndexers {
+		indexers[k] = v
+	}
 	return &Store[E]{
 		dir: opts.Dir,
 
@@ -55,6 +62,8 @@ func NewStore[E api.Object](opts Options[E]) (*Store[E], error) {
 
 		watches:         sets.New[*watch[E]](),
 		watchBufferSize: opts.WatchBufferSize,
+
+		indexers: indexers,
 	}, nil
 }
 
@@ -63,12 +72,13 @@ type Store[E api.Object] struct {
 
 	idMu *utilssync.MutexMap[string]
 
-	newFunc        func() E
-	createStrategy CreateStrategy[E]
-
+	newFunc         func() E
+	createStrategy  CreateStrategy[E]
 	watchBufferSize int
 	watchesMu       sync.RWMutex
 	watches         sets.Set[*watch[E]]
+
+	indexers map[string]store.IndexerFunc[E]
 }
 
 type CreateStrategy[E api.Object] interface {
@@ -192,7 +202,20 @@ func (s *Store[E]) Delete(_ context.Context, id string) error {
 	return nil
 }
 
-func (s *Store[E]) List(ctx context.Context) ([]E, error) {
+func (s *Store[E]) List(ctx context.Context, opts ...store.ListOption) ([]E, error) {
+	listOpts := &store.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(listOpts)
+	}
+
+	if listOpts.FieldSelector != nil {
+		for _, req := range listOpts.FieldSelector.Requirements() {
+			if _, ok := s.indexers[req.Field]; !ok {
+				return nil, fmt.Errorf("field selector references unindexed field %q", req.Field)
+			}
+		}
+	}
+
 	entries, err := os.ReadDir(s.dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list objects: %w", err)
@@ -208,6 +231,22 @@ func (s *Store[E]) List(ctx context.Context) ([]E, error) {
 		object, err := s.Get(ctx, entry.Name())
 		if err != nil {
 			return nil, fmt.Errorf("failed to read object: %w", err)
+		}
+
+		if listOpts.LabelSelector != nil && !listOpts.LabelSelector.Matches(labels.Set(object.GetLabels())) {
+			continue
+		}
+
+		if listOpts.FieldSelector != nil {
+			merged := fields.Set{}
+			for _, req := range listOpts.FieldSelector.Requirements() {
+				if fn, ok := s.indexers[req.Field]; ok {
+					merged[req.Field] = fn(object)
+				}
+			}
+			if !listOpts.FieldSelector.Matches(merged) {
+				continue
+			}
 		}
 
 		objs = append(objs, object)

--- a/storeutils/host/store.go
+++ b/storeutils/host/store.go
@@ -17,8 +17,8 @@ import (
 	"github.com/ironcore-dev/provider-utils/storeutils/store"
 	utilssync "github.com/ironcore-dev/provider-utils/storeutils/sync"
 	"github.com/ironcore-dev/provider-utils/storeutils/utils"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -52,7 +52,8 @@ func NewStore[E api.Object](opts Options[E]) (*Store[E], error) {
 	for k, v := range opts.FieldIndexers {
 		indexers[k] = v
 	}
-	return &Store[E]{
+
+	s := &Store[E]{
 		dir: opts.Dir,
 
 		idMu: utilssync.NewMutexMap[string](),
@@ -63,8 +64,27 @@ func NewStore[E api.Object](opts Options[E]) (*Store[E], error) {
 		watches:         sets.New[*watch[E]](),
 		watchBufferSize: opts.WatchBufferSize,
 
-		indexers: indexers,
-	}, nil
+		indexers:   indexers,
+		labelIndex: make(map[string]map[string]sets.Set[string]),
+		fieldIndex: make(map[string]map[string]sets.Set[string]),
+	}
+
+	entries, err := os.ReadDir(opts.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("error reading store directory: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		obj, err := s.get(entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("error warming up index: %w", err)
+		}
+		s.addToIndex(obj)
+	}
+
+	return s, nil
 }
 
 type Store[E api.Object] struct {
@@ -79,10 +99,130 @@ type Store[E api.Object] struct {
 	watches         sets.Set[*watch[E]]
 
 	indexers map[string]store.IndexerFunc[E]
+
+	indexMu    sync.RWMutex
+	labelIndex map[string]map[string]sets.Set[string]
+	fieldIndex map[string]map[string]sets.Set[string]
 }
 
 type CreateStrategy[E api.Object] interface {
 	PrepareForCreate(obj E)
+}
+
+func (s *Store[E]) addToIndex(obj E) {
+	s.indexMu.Lock()
+	defer s.indexMu.Unlock()
+
+	id := obj.GetID()
+	for k, v := range obj.GetLabels() {
+		if s.labelIndex[k] == nil {
+			s.labelIndex[k] = make(map[string]sets.Set[string])
+		}
+		if s.labelIndex[k][v] == nil {
+			s.labelIndex[k][v] = sets.New[string]()
+		}
+		s.labelIndex[k][v].Insert(id)
+	}
+	for field, fn := range s.indexers {
+		v := fn(obj)
+		if s.fieldIndex[field] == nil {
+			s.fieldIndex[field] = make(map[string]sets.Set[string])
+		}
+		if s.fieldIndex[field][v] == nil {
+			s.fieldIndex[field][v] = sets.New[string]()
+		}
+		s.fieldIndex[field][v].Insert(id)
+	}
+}
+
+func (s *Store[E]) removeFromIndex(obj E) {
+	s.indexMu.Lock()
+	defer s.indexMu.Unlock()
+
+	id := obj.GetID()
+	for k, v := range obj.GetLabels() {
+		if m := s.labelIndex[k]; m != nil {
+			m[v].Delete(id)
+		}
+	}
+	for field, fn := range s.indexers {
+		v := fn(obj)
+		if m := s.fieldIndex[field]; m != nil {
+			m[v].Delete(id)
+		}
+	}
+}
+
+// resolveCandidateIDs returns the set of IDs matching all positive index-backed
+// requirements. Returns nil when no filters are present (full scan needed).
+// Negative label requirements (NotIn, DoesNotExist) are skipped here and
+// applied as a post-filter in List.
+func (s *Store[E]) resolveCandidateIDs(opts *store.ListOptions) sets.Set[string] {
+	s.indexMu.RLock()
+	defer s.indexMu.RUnlock()
+
+	var result sets.Set[string]
+	hasFilter := false
+
+	if opts.LabelSelector != nil {
+		reqs, selectable := opts.LabelSelector.Requirements()
+		if !selectable {
+			return sets.New[string]()
+		}
+		for _, req := range reqs {
+			switch req.Operator() {
+			case selection.Equals, selection.DoubleEquals, selection.In:
+				hasFilter = true
+				ids := sets.New[string]()
+				if m := s.labelIndex[req.Key()]; m != nil {
+					for v := range req.Values() {
+						if s := m[v]; s != nil {
+							ids = ids.Union(s)
+						}
+					}
+				}
+				result = indexIntersect(result, ids)
+			case selection.Exists:
+				hasFilter = true
+				ids := sets.New[string]()
+				if m := s.labelIndex[req.Key()]; m != nil {
+					for _, s := range m {
+						ids = ids.Union(s)
+					}
+				}
+				result = indexIntersect(result, ids)
+			}
+		}
+	}
+
+	if opts.FieldSelector != nil {
+		for _, req := range opts.FieldSelector.Requirements() {
+			hasFilter = true
+			ids := sets.New[string]()
+			if m := s.fieldIndex[req.Field]; m != nil {
+				if s := m[req.Value]; s != nil {
+					ids = s.Union(sets.New[string]())
+				}
+			}
+			result = indexIntersect(result, ids)
+		}
+	}
+
+	if !hasFilter {
+		return nil
+	}
+	if result == nil {
+		return sets.New[string]()
+	}
+	return result
+}
+
+// indexIntersect intersects a and b. A nil a means "universe" — returns a copy of b.
+func indexIntersect(a, b sets.Set[string]) sets.Set[string] {
+	if a == nil {
+		return b.Union(sets.New[string]())
+	}
+	return a.Intersection(b)
 }
 
 func (s *Store[E]) Create(_ context.Context, obj E) (E, error) {
@@ -109,6 +249,8 @@ func (s *Store[E]) Create(_ context.Context, obj E) (E, error) {
 	if err != nil {
 		return utils.Zero[E](), err
 	}
+
+	s.addToIndex(obj)
 
 	s.enqueue(store.WatchEvent[E]{
 		Type:   store.WatchEventTypeCreated,
@@ -160,6 +302,9 @@ func (s *Store[E]) Update(_ context.Context, obj E) (E, error) {
 	if err != nil {
 		return utils.Zero[E](), err
 	}
+
+	s.removeFromIndex(oldObj)
+	s.addToIndex(obj)
 
 	s.enqueue(store.WatchEvent[E]{
 		Type:   store.WatchEventTypeUpdated,
@@ -216,6 +361,23 @@ func (s *Store[E]) List(ctx context.Context, opts ...store.ListOption) ([]E, err
 		}
 	}
 
+	candidateIDs := s.resolveCandidateIDs(listOpts)
+
+	if candidateIDs != nil {
+		var objs []E
+		for _, id := range candidateIDs.UnsortedList() {
+			obj, err := s.Get(ctx, id)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read object: %w", err)
+			}
+			if listOpts.LabelSelector != nil && !listOpts.LabelSelector.Matches(labels.Set(obj.GetLabels())) {
+				continue
+			}
+			objs = append(objs, obj)
+		}
+		return objs, nil
+	}
+
 	entries, err := os.ReadDir(s.dir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list objects: %w", err)
@@ -235,18 +397,6 @@ func (s *Store[E]) List(ctx context.Context, opts ...store.ListOption) ([]E, err
 
 		if listOpts.LabelSelector != nil && !listOpts.LabelSelector.Matches(labels.Set(object.GetLabels())) {
 			continue
-		}
-
-		if listOpts.FieldSelector != nil {
-			merged := fields.Set{}
-			for _, req := range listOpts.FieldSelector.Requirements() {
-				if fn, ok := s.indexers[req.Field]; ok {
-					merged[req.Field] = fn(object)
-				}
-			}
-			if !listOpts.FieldSelector.Matches(merged) {
-				continue
-			}
 		}
 
 		objs = append(objs, object)
@@ -301,6 +451,8 @@ func (s *Store[E]) set(obj E) (E, error) {
 }
 
 func (s *Store[E]) delete(obj E) error {
+	s.removeFromIndex(obj)
+
 	if err := os.Remove(filepath.Join(s.dir, obj.GetID())); err != nil {
 		return fmt.Errorf("failed to delete object from store: %w", err)
 	}

--- a/storeutils/host/store_test.go
+++ b/storeutils/host/store_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Store", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(obj).NotTo(BeNil())
+		DeferCleanup(dummyStore.Delete, ctx, "test-id")
 
 		By("checking that the store object exists")
 		data, err := os.ReadFile(filepath.Join(tmpDir, obj.ID))
@@ -41,5 +42,147 @@ var _ = Describe("Store", func() {
 			Object: obj,
 		}
 		Eventually(watch.Events()).Should(Receive(event))
+	})
+
+	It("should filter objects by labels using MatchingLabels", func(ctx SpecContext) {
+		By("creating objects with different labels")
+		_, err := dummyStore.Create(ctx, &Dummy{
+			Metadata: api.Metadata{
+				ID:     "labeled-a",
+				Labels: map[string]string{"app": "foo", "env": "prod"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(dummyStore.Delete, ctx, "labeled-a")
+
+		_, err = dummyStore.Create(ctx, &Dummy{
+			Metadata: api.Metadata{
+				ID:     "labeled-b",
+				Labels: map[string]string{"app": "bar", "env": "prod"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(dummyStore.Delete, ctx, "labeled-b")
+
+		_, err = dummyStore.Create(ctx, &Dummy{
+			Metadata: api.Metadata{
+				ID:     "labeled-c",
+				Labels: map[string]string{"app": "foo", "env": "dev"},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(dummyStore.Delete, ctx, "labeled-c")
+
+		By("listing without filter returns all objects")
+		all, err := dummyStore.List(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(all).To(HaveLen(3))
+
+		By("listing with MatchingLabels filters correctly")
+		filtered, err := dummyStore.List(ctx, store.MatchingLabels{"app": "foo"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(2))
+		for _, obj := range filtered {
+			Expect(obj.GetLabels()["app"]).To(Equal("foo"))
+		}
+
+		By("listing with multiple label selectors")
+		filtered, err = dummyStore.List(ctx, store.MatchingLabels{"app": "foo", "env": "prod"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(1))
+		Expect(filtered[0].GetID()).To(Equal("labeled-a"))
+
+		By("listing with HasLabels filters by key existence")
+		filtered, err = dummyStore.List(ctx, store.HasLabels{"env"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(3))
+
+		By("listing with HasLabels for a non-existent key")
+		filtered, err = dummyStore.List(ctx, store.HasLabels{"missing"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(BeEmpty())
+
+		By("combining MatchingLabels and HasLabels")
+		filtered, err = dummyStore.List(ctx, store.MatchingLabels{"env": "prod"}, store.HasLabels{"app"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(2))
+	})
+
+	It("should filter objects by fields using MatchingFields", func(ctx SpecContext) {
+		By("creating objects with different spec values")
+		_, err := dummyStoreField.Create(ctx, &Dummy{
+			Metadata: api.Metadata{ID: "field-ssd-a"},
+			Spec:     "ssd",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(dummyStoreField.Delete, ctx, "field-ssd-a")
+
+		_, err = dummyStoreField.Create(ctx, &Dummy{
+			Metadata: api.Metadata{ID: "field-ssd-b"},
+			Spec:     "ssd",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(dummyStoreField.Delete, ctx, "field-ssd-b")
+
+		_, err = dummyStoreField.Create(ctx, &Dummy{
+			Metadata: api.Metadata{ID: "field-hdd"},
+			Spec:     "hdd",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(dummyStoreField.Delete, ctx, "field-hdd")
+
+		By("listing with MatchingFields filters by field value")
+		filtered, err := dummyStoreField.List(ctx, store.MatchingFields{"spec": "ssd"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(2))
+		for _, obj := range filtered {
+			Expect(obj.Spec).To(Equal("ssd"))
+		}
+
+		By("listing with MatchingFields returns nothing for unmatched value")
+		filtered, err = dummyStoreField.List(ctx, store.MatchingFields{"spec": "nvme"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(BeEmpty())
+	})
+
+	It("should apply label and field selectors as AND when both are set", func(ctx SpecContext) {
+		_, err := dummyStoreField.Create(ctx, &Dummy{
+			Metadata: api.Metadata{
+				ID:     "combined-a",
+				Labels: map[string]string{"env": "prod"},
+			},
+			Spec: "ssd",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(dummyStoreField.Delete, ctx, "combined-a")
+
+		_, err = dummyStoreField.Create(ctx, &Dummy{
+			Metadata: api.Metadata{
+				ID:     "combined-b",
+				Labels: map[string]string{"env": "prod"},
+			},
+			Spec: "hdd",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(dummyStoreField.Delete, ctx, "combined-b")
+
+		_, err = dummyStoreField.Create(ctx, &Dummy{
+			Metadata: api.Metadata{
+				ID:     "combined-c",
+				Labels: map[string]string{"env": "dev"},
+			},
+			Spec: "ssd",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(dummyStoreField.Delete, ctx, "combined-c")
+
+		By("only the object matching both selectors is returned")
+		filtered, err := dummyStoreField.List(ctx,
+			store.MatchingLabels{"env": "prod"},
+			store.MatchingFields{"spec": "ssd"},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filtered).To(HaveLen(1))
+		Expect(filtered[0].GetID()).To(Equal("combined-a"))
 	})
 })

--- a/storeutils/store/listoptions.go
+++ b/storeutils/store/listoptions.go
@@ -4,12 +4,14 @@
 package store
 
 import (
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 )
 
 type ListOptions struct {
 	LabelSelector labels.Selector
+	FieldSelector fields.Selector
 }
 
 type ListOption interface {
@@ -28,7 +30,10 @@ type HasLabels []string
 func (h HasLabels) ApplyToList(o *ListOptions) {
 	sel := labels.NewSelector()
 	for _, key := range h {
-		req, _ := labels.NewRequirement(key, selection.Exists, nil)
+		req, err := labels.NewRequirement(key, selection.Exists, nil)
+		if err != nil {
+			continue
+		}
 		sel = sel.Add(*req)
 	}
 	o.LabelSelector = andSelectors(o.LabelSelector, sel)
@@ -40,4 +45,15 @@ func andSelectors(existing, additional labels.Selector) labels.Selector {
 	}
 	reqs, _ := additional.Requirements()
 	return existing.Add(reqs...)
+}
+
+type MatchingFields fields.Set
+
+func (m MatchingFields) ApplyToList(o *ListOptions) {
+	sel := fields.Set(m).AsSelector()
+	if o.FieldSelector == nil {
+		o.FieldSelector = sel
+	} else {
+		o.FieldSelector = fields.AndSelectors(o.FieldSelector, sel)
+	}
 }

--- a/storeutils/store/listoptions.go
+++ b/storeutils/store/listoptions.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package store
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type ListOptions struct {
+	LabelSelector labels.Selector
+}
+
+type ListOption interface {
+	ApplyToList(*ListOptions)
+}

--- a/storeutils/store/listoptions.go
+++ b/storeutils/store/listoptions.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 type ListOptions struct {
@@ -13,4 +14,30 @@ type ListOptions struct {
 
 type ListOption interface {
 	ApplyToList(*ListOptions)
+}
+
+type MatchingLabels labels.Set
+
+func (m MatchingLabels) ApplyToList(o *ListOptions) {
+	sel := labels.SelectorFromSet(labels.Set(m))
+	o.LabelSelector = andSelectors(o.LabelSelector, sel)
+}
+
+type HasLabels []string
+
+func (h HasLabels) ApplyToList(o *ListOptions) {
+	sel := labels.NewSelector()
+	for _, key := range h {
+		req, _ := labels.NewRequirement(key, selection.Exists, nil)
+		sel = sel.Add(*req)
+	}
+	o.LabelSelector = andSelectors(o.LabelSelector, sel)
+}
+
+func andSelectors(existing, additional labels.Selector) labels.Selector {
+	if existing == nil {
+		return additional
+	}
+	reqs, _ := additional.Requirements()
+	return existing.Add(reqs...)
 }

--- a/storeutils/store/store.go
+++ b/storeutils/store/store.go
@@ -42,12 +42,14 @@ const (
 	WatchEventTypeDeleted WatchEventType = "Deleted"
 )
 
+type IndexerFunc[E api.Object] func(E) string
+
 type Store[E api.Object] interface {
 	Create(ctx context.Context, obj E) (E, error)
 	Get(ctx context.Context, id string) (E, error)
 	Update(ctx context.Context, obj E) (E, error)
 	Delete(ctx context.Context, id string) error
-	List(ctx context.Context) ([]E, error)
+	List(ctx context.Context, opts ...ListOption) ([]E, error)
 
 	Watch(ctx context.Context) (Watch[E], error)
 }


### PR DESCRIPTION
# Proposed Changes
Add indexing for labels and indexed fields (specified via `FieldIndexers` when initializing a `host.Store`)

This is an optimization based on #56. #56 allows filtering `List` queries by providing `ListOptions`. However, even when filtering like this the store will still fetch all object from store and apply filtering later. This PR optimizes this by adding indexes for labels and fields so the store only needs to fetch the objects from the index.

**Note:** This is an early draft to show how indexing could be implemented after #56 has been merged. It is not tested properly yet.
